### PR TITLE
AI/librediffusion: support-kind package with real binary release assets

### DIFF
--- a/AI/librediffusion.json
+++ b/AI/librediffusion.json
@@ -1,18 +1,15 @@
 {
     "name": "LibreDiffusion",
     "raw_name": "librediffusion",
-    "kind": "ai-model",
+    "kind": "support",
     "short": "StreamDiffusion real-time image generation",
-    "license": "APGL-3.0, Apache-2.0",
+    "license": "AGPL-3.0, Apache-2.0",
     "size": "20MB",
     "key": "d0add344-cb23-4d3f-817b-3619505565d1",
-    "version": 3,
-    "file": "https://github.com/jcelerier/librediffusion/archive/refs/heads/main.zip",
+    "version": 4,
+    "file": "https://github.com/jcelerier/librediffusion/archive/refs/tags/v1.0.1.zip",
     "url": "https://github.com/jcelerier/librediffusion",
-    "category": "AI Models",  
-    "windows-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.0/x86_64-pc-windows-msvc.zip",
-    "windows-amd64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.0/x86_64-pc-windows-msvc.zip",
-    "linux-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.0/x86_64-unknown-linux-gnu.zip",
-    "linux-amd64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.0/x86_64-unknown-linux-gnu.zip"
-
+    "category": "AI Models",
+    "windows-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.1/x86_64-pc-windows-msvc.zip",
+    "linux-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.1/x86_64-unknown-linux-gnu.zip"
 }

--- a/AI/librediffusion.json
+++ b/AI/librediffusion.json
@@ -7,7 +7,6 @@
     "size": "20MB",
     "key": "d0add344-cb23-4d3f-817b-3619505565d1",
     "version": 4,
-    "file": "https://github.com/jcelerier/librediffusion/archive/refs/tags/v2.0.0.zip",
     "url": "https://github.com/jcelerier/librediffusion",
     "category": "AI Models",
     "windows-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v2.0.0/x86_64-pc-windows-msvc.zip",

--- a/AI/librediffusion.json
+++ b/AI/librediffusion.json
@@ -7,9 +7,9 @@
     "size": "20MB",
     "key": "d0add344-cb23-4d3f-817b-3619505565d1",
     "version": 4,
-    "file": "https://github.com/jcelerier/librediffusion/archive/refs/tags/v1.0.1.zip",
+    "file": "https://github.com/jcelerier/librediffusion/archive/refs/tags/v2.0.0.zip",
     "url": "https://github.com/jcelerier/librediffusion",
     "category": "AI Models",
-    "windows-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.1/x86_64-pc-windows-msvc.zip",
-    "linux-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v1.0.1/x86_64-unknown-linux-gnu.zip"
+    "windows-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v2.0.0/x86_64-pc-windows-msvc.zip",
+    "linux-x86_64": "https://github.com/jcelerier/librediffusion/releases/download/v2.0.0/x86_64-unknown-linux-gnu.zip"
 }


### PR DESCRIPTION
Fixes the LibreDiffusion package manifest (resolves jcelerier/librediffusion#5 — the `v1.0.0` URLs 404 because no assets were attached).

- **`kind: "ai-model"` → `"support"`** so the native library extracts to `{RootPath}/support/librediffusion`, where score makes it loadable: `AddDllDirectory` on Windows, and eager `dlopen(RTLD_GLOBAL)` on Linux/macOS (see ossia/score#2090). The statically-built LibreDiffusion addon then resolves its bare-name `dlopen`.
- **Point URLs at `v1.0.1`** (binaries published by jcelerier/librediffusion#10). `file` keeps the source archive so the **Python export toolchain** (`train-lora.py` + `src/`, `klein/`, `img2img_turbo/`, `pyproject.toml`) installs alongside the library for building engines.
- **Drop dead `*-amd64` keys** — score only queries `linux-x86_64` / `windows-x86_64` (`addonArchitecture()`).
- Fix `APGL` → `AGPL` typo.

Depends on: jcelerier/librediffusion#10 (publishes the assets) + a `v1.0.1` tag on librediffusion.