### PR TITLE
Add the depth-camera package

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -11,6 +11,7 @@
 
     "https://raw.githubusercontent.com/ossia/uv/main/addon.json",
     "https://raw.githubusercontent.com/ossia/cuda/refs/tags/v12.9/addon.json",
+    "https://raw.githubusercontent.com/ossia/score-addon-orbbec/master/depth-camera.json",
 
     "https://raw.githubusercontent.com/ossia/score-packages/master/Addons/wasm-remote.json",
 


### PR DESCRIPTION
Lists the depth-camera support package from
[ossia/score-addon-orbbec](https://github.com/ossia/score-addon-orbbec).

The Depth Camera Input device links no camera SDK: it loads whatever is in
`packages/depth-camera` at runtime, behind a small C ABI. That is what lets the
plug-in be statically built into score while five camera SDKs — which together
would add hundreds of megabytes — arrive as an optional download. Until the
package is installed the device works and says so.

| Camera | Backend |
|---|---|
| Orbbec Femto Mega / Bolt, Gemini, Astra, DaBai | `orbbec`, USB and Ethernet |
| Kinect v2 (Xbox One) | `freenect2` |
| Kinect v1 (Xbox 360) | `freenect` |
| Azure Kinect DK | `k4a` |
| Intel RealSense D400/D500/L500/SR300 | `realsense` |

`kind` is `library`, so it installs to `packages/depth-camera`, which is where
`BackendRegistry` looks.

**Architectures.** `linux-x86_64`, `darwin-aarch64` and `windows-x86_64` today.
`linux-aarch64`, `darwin-x86_64` and `windows-aarch64` are building now and will
be added to the same manifest — the URL here is on `master` rather than a tag
precisely so that does not need another change to this repo.

**Not shipped**: Microsoft's `libk4a` runtime, which the Azure Kinect backend
`dlopen`s and which is not ours to redistribute. The backend tells the user
where to put it. There is no Azure Kinect backend at all on macOS or on either
ARM target, because Microsoft never released a runtime for them.

**Linux**: the package carries the udev rules each SDK needs in its `udev/`
directory. Without them the camera nodes stay root-owned and every SDK reports
no devices, which is indistinguishable from nothing being plugged in.

Each backend is built and checked per platform in CI: the expected set is
asserted (a missing system dependency otherwise drops one silently and the build
still passes), and each is checked to export exactly its single entry point —
enforced on Linux and macOS, reported on Windows, where a PE has no global
symbol namespace for it to matter in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uvR7UomMUJRaHbfEG1gk5